### PR TITLE
Added saving/loading of embeds and enabled ANSI text file uploads to vault

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -43,9 +43,19 @@ def convert_pdf_to_text():
 
 # Function to upload a text file and append to vault.txt
 def upload_txtfile():
+
+    user_file_encoding="utf-8"
+
     file_path = filedialog.askopenfilename(filetypes=[("Text Files", "*.txt")])
     if file_path:
-        with open(file_path, 'r', encoding="utf-8") as txt_file:
+
+        try:
+            with open(file_path, 'r', encoding="utf-8") as txt_file:
+                text = txt_file.read()
+        except:
+            user_file_encoding = "ansi"
+
+        with open(file_path, 'r', encoding=user_file_encoding) as txt_file:
             text = txt_file.read()
             
             # Normalize whitespace and clean up text


### PR DESCRIPTION
Two very basic additions:

- The embeding vectors can now be saved and loaded. This was implemented using torch.load() and torch.save(). If the user decides to save tensors, they will need to manually delete them if they want to generate embedings from vault again. This is to minimize required input during normal execution on the console.

- Added a try-except statement on the upload file to allow for decoding of ANSI-encoding text files. I don't know of how many use cases this helps with but it is an absolute necessity for Spanish speakers.